### PR TITLE
Log release version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: run
 run:
-	go run ./cmd/frigg/main.go
+	go run -ldflags="-X 'main.release=`git rev-parse --short=8 HEAD`'" ./cmd/frigg/main.go
 
 .PHONY: test
 test:

--- a/cmd/frigg/integration_test.go
+++ b/cmd/frigg/integration_test.go
@@ -26,6 +26,7 @@ func TestFriggIntegration(t *testing.T) {
 	// cancelled manually.
 	defer cancel()
 	eg, ctx := errgroup.WithContext(ctx)
+	release = "integration-test"
 
 	eg.Go(func() error {
 		return run(ctx, &out)
@@ -46,8 +47,8 @@ func TestFriggIntegration(t *testing.T) {
 	})
 
 	logs := out.String()
-	assert.Contains(t, logs, `"msg":"Registered route","path":"/health","methods":["GET"]`)
-	assert.Contains(t, logs, `"msg":"Registered route","path":"/metrics","methods":["GET"]`)
+	assert.Contains(t, logs, `"msg":"Registered route","release":"integration-test","path":"/health","methods":["GET"]`)
+	assert.Contains(t, logs, `"msg":"Registered route","release":"integration-test","path":"/metrics","methods":["GET"]`)
 
 	t.Run("shuts down gracefully", func(t *testing.T) {
 		cancel()

--- a/cmd/frigg/main.go
+++ b/cmd/frigg/main.go
@@ -18,6 +18,9 @@ import (
 	"github.com/LasseHels/frigg/pkg/server"
 )
 
+// release is set through the linker at build time, generally from a git sha. Used for logging and error reporting.
+var release string
+
 func main() {
 	os.Exit(start())
 }
@@ -81,5 +84,8 @@ func logger(w io.Writer) *slog.Logger {
 	handler := slog.NewJSONHandler(w, &slog.HandlerOptions{
 		Level: slog.LevelInfo, // TODO: Read from configuration.
 	})
-	return slog.New(handler)
+	l := slog.New(handler)
+	l = l.With(slog.String("release", release))
+
+	return l
 }


### PR DESCRIPTION
Update Frigg to include the short git sha from which the program was built in all logs emitted by the program.