### PR TITLE
Dashboard pruner dry mode

### DIFF
--- a/pkg/grafana/dashboard_pruner.go
+++ b/pkg/grafana/dashboard_pruner.go
@@ -51,7 +51,7 @@ type NewDashboardPrunerOptions struct {
 	Dry bool
 }
 
-func NewDashboardPruner(opts NewDashboardPrunerOptions) *DashboardPruner {
+func NewDashboardPruner(opts *NewDashboardPrunerOptions) *DashboardPruner {
 	logger := opts.Logger.With(slog.Bool("dry", opts.Dry))
 
 	return &DashboardPruner{

--- a/pkg/grafana/dashboard_pruner_test.go
+++ b/pkg/grafana/dashboard_pruner_test.go
@@ -57,7 +57,7 @@ func TestDashboardPruner_Start(t *testing.T) {
 
 		l, logs := logger()
 
-		pruner := NewDashboardPruner(NewDashboardPrunerOptions{
+		pruner := NewDashboardPruner(&NewDashboardPrunerOptions{
 			Grafana:  mockClient,
 			Logger:   l,
 			Interval: time.Hour,
@@ -65,10 +65,11 @@ func TestDashboardPruner_Start(t *testing.T) {
 
 		pruner.Start(ctx)
 
-		expectedLogs := `{"level":"INFO","msg":"Starting dashboard pruner","interval":"1h0m0s"}
-{"level":"INFO","msg":"Pruning Grafana dashboards"}
-{"level":"ERROR","msg":"Failed to prune dashboards","error":"fetching all Grafana dashboards: could not reach Grafana"}
-{"level":"INFO","msg":"Stopping dashboard pruner"}
+		//nolint:lll
+		expectedLogs := `{"level":"INFO","msg":"Starting dashboard pruner","dry":false,"interval":"1h0m0s"}
+{"level":"INFO","msg":"Pruning Grafana dashboards","dry":false}
+{"level":"ERROR","msg":"Failed to prune dashboards","dry":false,"error":"fetching all Grafana dashboards: could not reach Grafana"}
+{"level":"INFO","msg":"Stopping dashboard pruner","dry":false}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})
@@ -101,7 +102,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 
 		l, logs := logger()
 
-		pruner := NewDashboardPruner(NewDashboardPrunerOptions{
+		pruner := NewDashboardPruner(&NewDashboardPrunerOptions{
 			Grafana:      mockClient,
 			Logger:       l,
 			Interval:     time.Hour,
@@ -114,10 +115,10 @@ func TestDashboardPruner_Prune(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, usedDashboardsCalled)
 
-		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards"}
-{"level":"INFO","msg":"Found all Grafana dashboards","count":0}
-{"level":"INFO","msg":"Found used Grafana dashboards","count":0}
-{"level":"INFO","msg":"Finished pruning Grafana dashboards","deleted_count":0,"uids":""}
+		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards","dry":false}
+{"level":"INFO","msg":"Found all Grafana dashboards","dry":false,"count":0}
+{"level":"INFO","msg":"Found used Grafana dashboards","dry":false,"count":0}
+{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"deleted_count":0,"uids":""}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})
@@ -155,7 +156,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 
 		l, logs := logger()
 
-		pruner := NewDashboardPruner(NewDashboardPrunerOptions{
+		pruner := NewDashboardPruner(&NewDashboardPrunerOptions{
 			Grafana:      mockClient,
 			Logger:       l,
 			Interval:     time.Hour,
@@ -168,12 +169,12 @@ func TestDashboardPruner_Prune(t *testing.T) {
 		require.NoError(t, err)
 
 		//nolint:lll
-		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards"}
-{"level":"INFO","msg":"Found all Grafana dashboards","count":2}
-{"level":"INFO","msg":"Found used Grafana dashboards","count":2}
-{"level":"DEBUG","msg":"Skipping used dashboard","uid":"dashboard1","name":"Dashboard 1","reads":10,"users":2,"range":"24h0m0s"}
-{"level":"DEBUG","msg":"Skipping used dashboard","uid":"dashboard2","name":"Dashboard 2","reads":5,"users":1,"range":"24h0m0s"}
-{"level":"INFO","msg":"Finished pruning Grafana dashboards","deleted_count":0,"uids":""}
+		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards","dry":false}
+{"level":"INFO","msg":"Found all Grafana dashboards","dry":false,"count":2}
+{"level":"INFO","msg":"Found used Grafana dashboards","dry":false,"count":2}
+{"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"uid":"dashboard1","name":"Dashboard 1","reads":10,"users":2,"range":"24h0m0s"}
+{"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"uid":"dashboard2","name":"Dashboard 2","reads":5,"users":1,"range":"24h0m0s"}
+{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"deleted_count":0,"uids":""}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})
@@ -221,7 +222,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 
 		l, logs := logger()
 
-		pruner := NewDashboardPruner(NewDashboardPrunerOptions{
+		pruner := NewDashboardPruner(&NewDashboardPrunerOptions{
 			Grafana:      mockClient,
 			Logger:       l,
 			Interval:     time.Hour,
@@ -235,15 +236,15 @@ func TestDashboardPruner_Prune(t *testing.T) {
 		assert.ElementsMatch(t, []string{"dashboard2", "dashboard3"}, deletedUIDs)
 
 		//nolint:lll
-		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards"}
-{"level":"INFO","msg":"Found all Grafana dashboards","count":3}
-{"level":"INFO","msg":"Found used Grafana dashboards","count":1}
-{"level":"DEBUG","msg":"Skipping used dashboard","uid":"dashboard1","name":"Dashboard 1","reads":10,"users":2,"range":"24h0m0s"}
-{"level":"INFO","msg":"Deleting unused dashboard","uid":"dashboard2","name":"Dashboard 2","raw_json":"{\"title\": \"Dashboard 2\"}"}
-{"level":"INFO","msg":"Deleted unused dashboard","uid":"dashboard2","name":"Dashboard 2","raw_json":"{\"title\": \"Dashboard 2\"}"}
-{"level":"INFO","msg":"Deleting unused dashboard","uid":"dashboard3","name":"Dashboard 3","raw_json":"{\"title\": \"Dashboard 3\"}"}
-{"level":"INFO","msg":"Deleted unused dashboard","uid":"dashboard3","name":"Dashboard 3","raw_json":"{\"title\": \"Dashboard 3\"}"}
-{"level":"INFO","msg":"Finished pruning Grafana dashboards","deleted_count":2,"uids":"dashboard2, dashboard3"}
+		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards","dry":false}
+{"level":"INFO","msg":"Found all Grafana dashboards","dry":false,"count":3}
+{"level":"INFO","msg":"Found used Grafana dashboards","dry":false,"count":1}
+{"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"uid":"dashboard1","name":"Dashboard 1","reads":10,"users":2,"range":"24h0m0s"}
+{"level":"INFO","msg":"Deleting unused dashboard","dry":false,"uid":"dashboard2","name":"Dashboard 2","raw_json":"{\"title\": \"Dashboard 2\"}"}
+{"level":"INFO","msg":"Deleted unused dashboard","dry":false,"uid":"dashboard2","name":"Dashboard 2","raw_json":"{\"title\": \"Dashboard 2\"}"}
+{"level":"INFO","msg":"Deleting unused dashboard","dry":false,"uid":"dashboard3","name":"Dashboard 3","raw_json":"{\"title\": \"Dashboard 3\"}"}
+{"level":"INFO","msg":"Deleted unused dashboard","dry":false,"uid":"dashboard3","name":"Dashboard 3","raw_json":"{\"title\": \"Dashboard 3\"}"}
+{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"deleted_count":2,"uids":"dashboard2, dashboard3"}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})
@@ -286,7 +287,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 
 		l, logs := logger()
 
-		pruner := NewDashboardPruner(NewDashboardPrunerOptions{
+		pruner := NewDashboardPruner(&NewDashboardPrunerOptions{
 			Grafana:      mockClient,
 			Logger:       l,
 			Interval:     time.Hour,
@@ -322,7 +323,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 
 		l, _ := logger()
 
-		pruner := NewDashboardPruner(NewDashboardPrunerOptions{
+		pruner := NewDashboardPruner(&NewDashboardPrunerOptions{
 			Grafana:      mockClient,
 			Logger:       l,
 			Interval:     time.Hour,
@@ -360,7 +361,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 
 		l, _ := logger()
 
-		pruner := NewDashboardPruner(NewDashboardPrunerOptions{
+		pruner := NewDashboardPruner(&NewDashboardPrunerOptions{
 			Grafana:      mockClient,
 			Logger:       l,
 			Interval:     time.Hour,
@@ -406,7 +407,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 
 		l, logs := logger()
 
-		pruner := NewDashboardPruner(NewDashboardPrunerOptions{
+		pruner := NewDashboardPruner(&NewDashboardPrunerOptions{
 			Grafana:      mockClient,
 			Logger:       l,
 			Interval:     time.Hour,
@@ -419,10 +420,10 @@ func TestDashboardPruner_Prune(t *testing.T) {
 		require.EqualError(t, err, "deleting unused dashboard dashboard1: dashboard delete failed")
 
 		//nolint:lll
-		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards"}
-{"level":"INFO","msg":"Found all Grafana dashboards","count":2}
-{"level":"INFO","msg":"Found used Grafana dashboards","count":0}
-{"level":"INFO","msg":"Deleting unused dashboard","uid":"dashboard1","name":"Dashboard 1","raw_json":"{\"title\": \"Dashboard 1\"}"}
+		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards","dry":false}
+{"level":"INFO","msg":"Found all Grafana dashboards","dry":false,"count":2}
+{"level":"INFO","msg":"Found used Grafana dashboards","dry":false,"count":0}
+{"level":"INFO","msg":"Deleting unused dashboard","dry":false,"uid":"dashboard1","name":"Dashboard 1","raw_json":"{\"title\": \"Dashboard 1\"}"}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})


### PR DESCRIPTION
This pull request adds a dry mode to the dashboard pruner. In dry mode, the pruner will only log which dashboards are unused instead of deleting them.