### PR TITLE
Test that a dashboard is deleted if it has only been read by an ignored user

### DIFF
--- a/cmd/frigg/testdata/integration_config.yaml
+++ b/cmd/frigg/testdata/integration_config.yaml
@@ -12,7 +12,7 @@ prune:
   interval: '1s'
   period: '10m'
   ignored_users:
-    - 'admin'
+    - 'sa-1-john-doe'
   labels:
     app: 'grafana'
     env: 'integration-test'

--- a/integrationtest/grafana.go
+++ b/integrationtest/grafana.go
@@ -146,7 +146,7 @@ func (g *Grafana) CreateAPIKey(t *testing.T, name string) string {
 }
 
 // CreateDashboard in Grafana using the traditional HTTP API.
-func (g *Grafana) CreateDashboard(t *testing.T, apiKey, uid string) {
+func (g *Grafana) CreateDashboard(t *testing.T, apiKey, name string) {
 	t.Helper()
 	// https://grafana.com/docs/grafana/v12.0/developers/http_api/dashboard/#create-dashboard.
 	url := fmt.Sprintf("http://%s/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards", g.host)
@@ -169,7 +169,7 @@ func (g *Grafana) CreateDashboard(t *testing.T, apiKey, uid string) {
     "version": 0
   }
 }
-`, uid, uid))
+`, name, name))
 
 	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, url, bytes.NewBuffer(payload))
 	require.NoError(t, err)
@@ -189,33 +189,33 @@ func (g *Grafana) CreateDashboard(t *testing.T, apiKey, uid string) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode, string(body))
 }
 
-func (g *Grafana) AssertDashboardExists(t assert.TestingT, apiKey, uid string) {
-	g.assertGetDashboardStatusCode(t, apiKey, uid, http.StatusOK)
+func (g *Grafana) AssertDashboardExists(t assert.TestingT, apiKey, name string) {
+	g.assertGetDashboardStatusCode(t, apiKey, name, http.StatusOK)
 }
 
-func (g *Grafana) AssertDashboardDoesNotExist(t assert.TestingT, apiKey, uid string) {
-	g.assertGetDashboardStatusCode(t, apiKey, uid, http.StatusNotFound)
+func (g *Grafana) AssertDashboardDoesNotExist(t assert.TestingT, apiKey, name string) {
+	g.assertGetDashboardStatusCode(t, apiKey, name, http.StatusNotFound)
 }
 
-func (g *Grafana) assertGetDashboardStatusCode(t assert.TestingT, apiKey, uid string, expectedStatusCode int) {
-	statusCode := g.getDashboard(t, apiKey, uid)
+func (g *Grafana) assertGetDashboardStatusCode(t assert.TestingT, apiKey, name string, expectedStatusCode int) {
+	statusCode := g.getDashboard(t, apiKey, name)
 	assert.Equal(
 		t,
 		expectedStatusCode,
 		statusCode,
-		"expected code %d when retrieving dashboard with UID %q",
+		"expected code %d when retrieving dashboard with name %q",
 		expectedStatusCode,
-		uid,
+		name,
 	)
 }
 
-// getDashboard by UID using the traditional HTTP API.
-func (g *Grafana) getDashboard(t assert.TestingT, apiKey, uid string) int {
+// getDashboard by name using the traditional HTTP API.
+func (g *Grafana) getDashboard(t assert.TestingT, apiKey, name string) int {
 	// https://grafana.com/docs/grafana/v12.0/developers/http_api/dashboard/#get-dashboard.
 	url := fmt.Sprintf(
 		"http://%s/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/%s",
 		g.host,
-		uid,
+		name,
 	)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)

--- a/pkg/grafana/dashboard_pruner.go
+++ b/pkg/grafana/dashboard_pruner.go
@@ -2,6 +2,7 @@ package grafana
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
@@ -116,7 +117,7 @@ func (d *DashboardPruner) prune(ctx context.Context) error {
 
 	d.logger.Info("Found used Grafana dashboards", slog.Int("count", len(used)))
 	usedDashboards := d.usedMap(used)
-	var deletedUIDs []string
+	var deleted []string
 
 	for _, dashboard := range all {
 		dashboardLogger := d.logger.With(
@@ -145,13 +146,13 @@ func (d *DashboardPruner) prune(ctx context.Context) error {
 			return errors.Wrapf(err, "deleting unused dashboard %s", dashboard.UID)
 		}
 		dashboardLogger.Info("Deleted unused dashboard", slog.String("raw_json", string(dashboard.Spec)))
-		deletedUIDs = append(deletedUIDs, dashboard.UID)
+		deleted = append(deleted, fmt.Sprintf("%s/%s", dashboard.Namespace, dashboard.Name))
 	}
 
 	d.logger.Info(
 		"Finished pruning Grafana dashboards",
-		slog.Int("deleted_count", len(deletedUIDs)),
-		slog.String("uids", strings.Join(deletedUIDs, ", ")),
+		slog.Int("deleted_count", len(deleted)),
+		slog.String("deleted_dashboards", strings.Join(deleted, ", ")),
 	)
 
 	return nil

--- a/pkg/grafana/dashboard_pruner_test.go
+++ b/pkg/grafana/dashboard_pruner_test.go
@@ -118,7 +118,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards","dry":false}
 {"level":"INFO","msg":"Found all Grafana dashboards","dry":false,"count":0}
 {"level":"INFO","msg":"Found used Grafana dashboards","dry":false,"count":0}
-{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"deleted_count":0,"uids":""}
+{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"deleted_count":0,"deleted_dashboards":""}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})
@@ -176,7 +176,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 {"level":"INFO","msg":"Found used Grafana dashboards","dry":false,"count":2}
 {"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"uid":"cbf15242-fec5-4272-be50-1f83322ecf2c","name":"dashboard1","namespace":"default","reads":10,"users":2,"range":"24h0m0s"}
 {"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"uid":"50c3ea9d-d578-4c0f-a9c4-128577783c03","name":"dashboard2","namespace":"default","reads":5,"users":1,"range":"24h0m0s"}
-{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"deleted_count":0,"uids":""}
+{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"deleted_count":0,"deleted_dashboards":""}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})
@@ -249,7 +249,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 {"level":"INFO","msg":"Deleted unused dashboard","dry":false,"uid":"441c13ff-dc1d-4d90-9984-b15532e626ff","name":"dashboard2","namespace":"default","raw_json":"{\"title\": \"Dashboard 2\"}"}
 {"level":"INFO","msg":"Deleting unused dashboard","dry":false,"uid":"541517b1-3e42-497b-8038-25905320396e","name":"dashboard3","namespace":"default","raw_json":"{\"title\": \"Dashboard 3\"}"}
 {"level":"INFO","msg":"Deleted unused dashboard","dry":false,"uid":"541517b1-3e42-497b-8038-25905320396e","name":"dashboard3","namespace":"default","raw_json":"{\"title\": \"Dashboard 3\"}"}
-{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"deleted_count":2,"uids":"441c13ff-dc1d-4d90-9984-b15532e626ff, 541517b1-3e42-497b-8038-25905320396e"}
+{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"deleted_count":2,"deleted_dashboards":"default/dashboard2, default/dashboard3"}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})
@@ -314,7 +314,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 {"level":"INFO","msg":"Found used Grafana dashboards","dry":true,"count":1}
 {"level":"INFO","msg":"Found unused dashboard, skipping deletion due to dry run","dry":true,"uid":"3f02045e-5d94-4dbe-94e8-1353b1aede29","name":"dashboard1","namespace":"blueberry"}
 {"level":"INFO","msg":"Found unused dashboard, skipping deletion due to dry run","dry":true,"uid":"952e2e84-2515-4f7c-b965-151671b3300c","name":"dashboard2","namespace":"blueberry"}
-{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":true,"deleted_count":0,"uids":""}
+{"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":true,"deleted_count":0,"deleted_dashboards":""}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})


### PR DESCRIPTION
This pull request expands Frigg's integration test to assert that a dashboard is deleted if all the dashboard's reads come from ignored users.