### PR TITLE
Add namespace support to Grafana client

### DIFF
--- a/cmd/frigg/integration_test.go
+++ b/cmd/frigg/integration_test.go
@@ -69,7 +69,7 @@ func TestFriggIntegration(t *testing.T) {
 	assert.Contains(
 		t,
 		logs,
-		`"msg":"Deleted unused dashboard","release":"integration-test","dry":false,"uid":`+
+		`"msg":"Deleted unused dashboard","release":"integration-test","dry":false,"namespace":"default","uid":`+
 			`"qXQslCwCEssfGqKRa9patJDjtRbOf5XNGwOXXjdRnx0X","name":"ignoreduserdashboard","namespace":"default",`+
 			`"raw_json":"{\"editable\":false,\"schemaVersion\":41,\"time\":{\"from\":\"now-6h\",\"to\":\"now\"},\`+
 			`"timepicker\":{},\"timezone\":\"browser\",\"title\":\"ignoreduserdashboard\"}"}`,
@@ -77,7 +77,7 @@ func TestFriggIntegration(t *testing.T) {
 	assert.Contains(
 		t,
 		logs,
-		`"msg":"Deleted unused dashboard","release":"integration-test","dry":false,"uid":`+
+		`"msg":"Deleted unused dashboard","release":"integration-test","dry":false,"namespace":"default","uid":`+
 			`"mspoU2EJfAXM0lQ8bBBUha0AszqQEKUKMjzu4Gc3rnEX","name":"unuseddashboard","namespace":"default",`+
 			`"raw_json":"{\"editable\":false,\"schemaVersion\":41,\"time\":{\"from\":\"now-6h\",\"to\":\"now\"},\`+
 			`"timepicker\":{},\"timezone\":\"browser\",\"title\":\"unuseddashboard\"}"}`,
@@ -85,7 +85,7 @@ func TestFriggIntegration(t *testing.T) {
 	assert.Contains(
 		t,
 		logs,
-		`"msg":"Finished pruning Grafana dashboards","release":"integration-test","dry":false,`+
+		`"msg":"Finished pruning Grafana dashboards","release":"integration-test","dry":false,"namespace":"default",`+
 			`"deleted_count":2,"deleted_dashboards":"default/ignoreduserdashboard, default/unuseddashboard"}`,
 	)
 

--- a/pkg/frigg/config.go
+++ b/pkg/frigg/config.go
@@ -140,6 +140,7 @@ func (c *Config) Initialise(logger *slog.Logger, gatherer prometheus.Gatherer, s
 	pruner := grafana.NewDashboardPruner(&grafana.NewDashboardPrunerOptions{
 		Grafana:        grafanaClient,
 		Logger:         logger,
+		Namespace:      "default",
 		Interval:       c.Prune.Interval,
 		IgnoredUsers:   c.Prune.IgnoredUsers,
 		Period:         c.Prune.Period,

--- a/pkg/grafana/grafana_test.go
+++ b/pkg/grafana/grafana_test.go
@@ -462,7 +462,7 @@ func TestClient_AllDashboards(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		dashboards, err := g.AllDashboards(t.Context())
+		dashboards, err := g.AllDashboards(t.Context(), "default")
 		require.EqualError(t, err, "getting dashboards page: unexpected status code: 500, body: the server is down")
 		assert.Nil(t, dashboards)
 		assert.Equal(t, 1, requestCount)
@@ -486,7 +486,7 @@ func TestClient_AllDashboards(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		dashboards, err := g.AllDashboards(t.Context())
+		dashboards, err := g.AllDashboards(t.Context(), "default")
 		require.EqualError(
 			t,
 			err,
@@ -583,7 +583,7 @@ func TestClient_AllDashboards(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		dashboards, err := g.AllDashboards(t.Context())
+		dashboards, err := g.AllDashboards(t.Context(), "default")
 		require.NoError(t, err)
 		require.Len(t, dashboards, 2)
 
@@ -697,7 +697,7 @@ func TestClient_AllDashboards(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		dashboards, err := g.AllDashboards(t.Context())
+		dashboards, err := g.AllDashboards(t.Context(), "default")
 		require.NoError(t, err)
 		require.Len(t, dashboards, 2)
 
@@ -727,7 +727,7 @@ func TestClient_DeleteDashboard(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = g.DeleteDashboard(t.Context(), "")
+		err = g.DeleteDashboard(t.Context(), "default", "")
 		require.EqualError(t, err, "dashboard UID must not be empty")
 	})
 
@@ -749,7 +749,7 @@ func TestClient_DeleteDashboard(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = g.DeleteDashboard(t.Context(), "dashboard-uid")
+		err = g.DeleteDashboard(t.Context(), "default", "dashboard-uid")
 		require.EqualError(t, err, "unexpected status code: 500, body: server error")
 	})
 
@@ -771,7 +771,7 @@ func TestClient_DeleteDashboard(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = g.DeleteDashboard(t.Context(), "dashboard-uid")
+		err = g.DeleteDashboard(t.Context(), "default", "dashboard-uid")
 		require.EqualError(
 			t,
 			err,
@@ -808,7 +808,7 @@ func TestClient_DeleteDashboard(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = g.DeleteDashboard(t.Context(), "dashboard-uid")
+		err = g.DeleteDashboard(t.Context(), "default", "dashboard-uid")
 		require.EqualError(
 			t,
 			err,
@@ -849,7 +849,7 @@ func TestClient_DeleteDashboard(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = g.DeleteDashboard(t.Context(), "dashboard-uid")
+		err = g.DeleteDashboard(t.Context(), "default", "dashboard-uid")
 		require.NoError(t, err)
 		assert.Equal(t, "/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/dashboard-uid", request.URL.Path)
 		assert.Equal(t, "Bearer abc123", request.Header.Get("Authorization"))
@@ -879,7 +879,7 @@ func TestClient_DeleteDashboard(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		err = g.DeleteDashboard(t.Context(), "dashboard-uid")
+		err = g.DeleteDashboard(t.Context(), "default", "dashboard-uid")
 		require.ErrorContains(t, err, "making request to Grafana")
 		require.ErrorContains(t, err, "simulated client error")
 	})


### PR DESCRIPTION
This commit adds namespace parameter support to the Grafana client methods that previously hardcoded the 'default' namespace.

Changes:
- Update AllDashboards() to accept namespace parameter
- Update DeleteDashboard() to accept namespace parameter
- Add namespace field to DashboardPruner struct
- Update all tests to pass namespace parameters
- Maintain backward compatibility by using 'default' namespace in config

This is the first of three PRs to support multiple namespaces in Frigg's dashboard pruning functionality.

Relates to #26