### PR TITLE
Fix data race in `TestFriggIntegration`

### DIFF
--- a/integration_test.go
+++ b/integration_test.go
@@ -306,7 +306,7 @@ type buffer struct {
 	buf bytes.Buffer
 }
 
-func (b *buffer) Write(p []byte) (n int, err error) {
+func (b *buffer) Write(p []byte) (int, error) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.Write(p)


### PR DESCRIPTION
This pull request fixes a data race in the `TestFriggIntegration` test:
```sh
go test -shuffle on -race ./...
-test.shuffle 1762002630691267000
==================
WARNING: DATA RACE
Read at 0x00c000317680 by goroutine 21:
  bytes.(*Buffer).String()
      /usr/local/go/src/bytes/buffer.go:77 +0x4e8
  github.com/LasseHels/frigg.TestFriggIntegration()
      /Users/lasse.hels/Projects/frigg/integration_test.go:101 +0x4d0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:560 +0x488
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:545 +0x300
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:540 +0x248
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:218 +0x20c
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:215 +0x124
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:560 +0x488
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:545 +0x300
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:540 +0x248
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:218 +0x20c
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:215 +0x124
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:560 +0x488
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:545 +0x300
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:540 +0x248
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:218 +0x20c
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:215 +0x124
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:162 +0x884
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:154 +0x7cc
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:134 +0x354
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:117 +0x124
  github.com/testcontainers/testcontainers-go/wait.(*MultiStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/all.go:83 +0x3e4
  github.com/testcontainers/testcontainers-go.init.func5.2()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:291 +0x298
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).startedHook()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:353 +0x23c
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:238 +0x220
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:233 +0x14c
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/generic.go:92 +0x358
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1208 +0x2160
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1122 +0x12b8
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1031 +0x11c
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/generic.go:76 +0x308
  github.com/LasseHels/frigg/integrationtest.NewGrafana()
      /Users/lasse.hels/Projects/frigg/integrationtest/grafana.go:55 +0x878
  github.com/LasseHels/frigg.setup()
      /Users/lasse.hels/Projects/frigg/integration_test.go:165 +0x46c
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:215 +0x124
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:162 +0x884
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:154 +0x7cc
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:134 +0x354
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:117 +0x124
  github.com/testcontainers/testcontainers-go/wait.(*MultiStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/all.go:83 +0x3e4
  github.com/testcontainers/testcontainers-go.init.func5.2()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:291 +0x298
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).startedHook()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:353 +0x23c
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:238 +0x220
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:233 +0x14c
  github.com/LasseHels/frigg/integrationtest.NewLoki()
      /Users/lasse.hels/Projects/frigg/integrationtest/loki.go:53 +0x554
  github.com/LasseHels/frigg/integrationtest.NewLoki()
      /Users/lasse.hels/Projects/frigg/integrationtest/loki.go:50 +0x4ec
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:154 +0x7cc
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:134 +0x354
  github.com/testcontainers/testcontainers-go.init.func5.2()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:291 +0x298
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).startedHook()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:353 +0x23c
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:238 +0x220
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:233 +0x14c
  github.com/testcontainers/testcontainers-go.(*DockerProvider).RunContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1460 +0x84
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1122 +0x12b8
  github.com/testcontainers/testcontainers-go.(*DockerProvider).RunContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1455 +0x64
  github.com/testcontainers/testcontainers-go.(*reaperSpawner).newReaper()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/reaper.go:420 +0x7b4
  github.com/testcontainers/testcontainers-go.(*reaperSpawner).reuseOrCreate()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/reaper.go:330 +0x13c
  github.com/testcontainers/testcontainers-go.(*reaperSpawner).reaper.(*reaperSpawner).retryLocked.func2()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/reaper.go:282 +0x78
  github.com/cenkalti/backoff/v4.doRetryNotify[go.shape.*uint8]()
      /Users/lasse.hels/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:88 +0x15c
  github.com/cenkalti/backoff/v4.RetryNotifyWithData[go.shape.*uint8]()
      /Users/lasse.hels/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:54 +0x70
  github.com/cenkalti/backoff/v4.RetryWithData[go.shape.*uint8]()
      /Users/lasse.hels/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:43 +0x18
  github.com/testcontainers/testcontainers-go.(*reaperSpawner).reaper()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/reaper.go:271 +0x2fc
  github.com/testcontainers/testcontainers-go.(*DockerContainer).connectReaper()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:902 +0x188
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1245 +0x2738
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1208 +0x2160
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1122 +0x12b8
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1031 +0x11c
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/generic.go:76 +0x308
  github.com/LasseHels/frigg/integrationtest.NewLoki()
      /Users/lasse.hels/Projects/frigg/integrationtest/loki.go:44 +0x44c
  github.com/LasseHels/frigg.setup()
      /Users/lasse.hels/Projects/frigg/integration_test.go:163 +0x108
  github.com/LasseHels/frigg.TestFriggIntegration()
      /Users/lasse.hels/Projects/frigg/integration_test.go:34 +0x1ac
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1997 +0x3c

Previous write at 0x00c000317680 by goroutine 665:
  bytes.(*Buffer).tryGrowByReslice()
      /usr/local/go/src/bytes/buffer.go:123 +0x98
  bytes.(*Buffer).Write()
      /usr/local/go/src/bytes/buffer.go:183 +0xac
  log/slog.(*commonHandler).handle()
      /usr/local/go/src/log/slog/handler.go:322 +0x6cc
  log/slog.(*JSONHandler).Handle()
      /usr/local/go/src/log/slog/json_handler.go:89 +0x5c
  log/slog.(*Logger).log()
      /usr/local/go/src/log/slog/logger.go:256 +0x178
  log/slog.(*Logger).Info()
      /usr/local/go/src/log/slog/logger.go:209 +0xf5c
  github.com/LasseHels/frigg/grafana.(*DashboardPruner).prune()
      /Users/lasse.hels/Projects/frigg/grafana/dashboard_pruner.go:155 +0xeb0
  github.com/LasseHels/frigg/grafana.(*DashboardPruner).tick()
      /Users/lasse.hels/Projects/frigg/grafana/dashboard_pruner.go:101 +0x3c
  github.com/LasseHels/frigg/grafana.(*DashboardPruner).Start()
      /Users/lasse.hels/Projects/frigg/grafana/dashboard_pruner.go:85 +0x138
  github.com/LasseHels/frigg/frigg.(*Frigg).Start.gowrap1()
      /Users/lasse.hels/Projects/frigg/frigg/frigg.go:42 +0x58

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1997 +0x6e0
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2477 +0x74
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x164
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2475 +0x734
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2337 +0xaf4
  main.main()
      _testmain.go:47 +0x100

Goroutine 665 (running) created at:
  github.com/LasseHels/frigg/frigg.(*Frigg).Start()
      /Users/lasse.hels/Projects/frigg/frigg/frigg.go:42 +0x9c
  github.com/LasseHels/frigg.run.func1()
      /Users/lasse.hels/Projects/frigg/main.go:85 +0x40
  golang.org/x/sync/errgroup.(*Group).add.func1()
      /Users/lasse.hels/go/pkg/mod/golang.org/x/sync@v0.15.0/errgroup/errgroup.go:128 +0xc0
==================
==================
WARNING: DATA RACE
Read at 0x00c0004a59a0 by goroutine 21:
  runtime.slicebytetostring()
      /usr/local/go/src/runtime/string.go:133 +0x0
  bytes.(*Buffer).String()
      /usr/local/go/src/bytes/buffer.go:77 +0x51c
  github.com/LasseHels/frigg.TestFriggIntegration()
      /Users/lasse.hels/Projects/frigg/integration_test.go:101 +0x4d0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:560 +0x488
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:545 +0x300
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:540 +0x248
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:218 +0x20c
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:215 +0x124
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:560 +0x488
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:545 +0x300
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:540 +0x248
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:218 +0x20c
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:215 +0x124
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:560 +0x488
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:545 +0x300
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Exec()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:540 +0x248
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:218 +0x20c
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:215 +0x124
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:162 +0x884
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:154 +0x7cc
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:134 +0x354
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:117 +0x124
  github.com/testcontainers/testcontainers-go/wait.(*MultiStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/all.go:83 +0x3e4
  github.com/testcontainers/testcontainers-go.init.func5.2()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:291 +0x298
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).startedHook()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:353 +0x23c
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:238 +0x220
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:233 +0x14c
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/generic.go:92 +0x358
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1208 +0x2160
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1122 +0x12b8
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1031 +0x11c
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/generic.go:76 +0x308
  github.com/LasseHels/frigg/integrationtest.NewGrafana()
      /Users/lasse.hels/Projects/frigg/integrationtest/grafana.go:55 +0x878
  github.com/LasseHels/frigg.setup()
      /Users/lasse.hels/Projects/frigg/integration_test.go:165 +0x46c
  github.com/testcontainers/testcontainers-go/wait.internalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:215 +0x124
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:162 +0x884
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.externalCheck()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:186 +0x13c
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:154 +0x7cc
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:134 +0x354
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:117 +0x124
  github.com/testcontainers/testcontainers-go/wait.(*MultiStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/all.go:83 +0x3e4
  github.com/testcontainers/testcontainers-go.init.func5.2()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:291 +0x298
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).startedHook()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:353 +0x23c
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:238 +0x220
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:233 +0x14c
  github.com/LasseHels/frigg/integrationtest.NewLoki()
      /Users/lasse.hels/Projects/frigg/integrationtest/loki.go:53 +0x554
  github.com/LasseHels/frigg/integrationtest.NewLoki()
      /Users/lasse.hels/Projects/frigg/integrationtest/loki.go:50 +0x4ec
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:154 +0x7cc
  github.com/testcontainers/testcontainers-go/wait.(*HostPortStrategy).WaitUntilReady()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/wait/host_port.go:134 +0x354
  github.com/testcontainers/testcontainers-go.init.func5.2()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:291 +0x298
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks.containerHookFn.func1()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:474 +0x7c8
  github.com/testcontainers/testcontainers-go.(*DockerContainer).applyLifecycleHooks()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:415 +0xf0
  github.com/testcontainers/testcontainers-go.(*DockerContainer).startedHook()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/lifecycle.go:353 +0x23c
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:238 +0x220
  github.com/testcontainers/testcontainers-go.(*DockerContainer).Start()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:233 +0x14c
  github.com/testcontainers/testcontainers-go.(*DockerProvider).RunContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1460 +0x84
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1122 +0x12b8
  github.com/testcontainers/testcontainers-go.(*DockerProvider).RunContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1455 +0x64
  github.com/testcontainers/testcontainers-go.(*reaperSpawner).newReaper()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/reaper.go:420 +0x7b4
  github.com/testcontainers/testcontainers-go.(*reaperSpawner).reuseOrCreate()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/reaper.go:330 +0x13c
  github.com/testcontainers/testcontainers-go.(*reaperSpawner).reaper.(*reaperSpawner).retryLocked.func2()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/reaper.go:282 +0x78
  github.com/cenkalti/backoff/v4.doRetryNotify[go.shape.*uint8]()
      /Users/lasse.hels/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:88 +0x15c
  github.com/cenkalti/backoff/v4.RetryNotifyWithData[go.shape.*uint8]()
      /Users/lasse.hels/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:54 +0x70
  github.com/cenkalti/backoff/v4.RetryWithData[go.shape.*uint8]()
      /Users/lasse.hels/go/pkg/mod/github.com/cenkalti/backoff/v4@v4.2.1/retry.go:43 +0x18
  github.com/testcontainers/testcontainers-go.(*reaperSpawner).reaper()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/reaper.go:271 +0x2fc
  github.com/testcontainers/testcontainers-go.(*DockerContainer).connectReaper()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:902 +0x188
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1245 +0x2738
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1208 +0x2160
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1122 +0x12b8
  github.com/testcontainers/testcontainers-go.(*DockerProvider).CreateContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/docker.go:1031 +0x11c
  github.com/testcontainers/testcontainers-go.GenericContainer()
      /Users/lasse.hels/go/pkg/mod/github.com/testcontainers/testcontainers-go@v0.37.0/generic.go:76 +0x308
  github.com/LasseHels/frigg/integrationtest.NewLoki()
      /Users/lasse.hels/Projects/frigg/integrationtest/loki.go:44 +0x44c
  github.com/LasseHels/frigg.setup()
      /Users/lasse.hels/Projects/frigg/integration_test.go:163 +0x108
  github.com/LasseHels/frigg.TestFriggIntegration()
      /Users/lasse.hels/Projects/frigg/integration_test.go:34 +0x1ac
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x164
  testing.(*T).Run.gowrap1()
      /usr/local/go/src/testing/testing.go:1997 +0x3c

Previous write at 0x00c0004a59a1 by goroutine 665:
  runtime.slicecopy()
      /usr/local/go/src/runtime/slice.go:355 +0x0
  bytes.(*Buffer).Write()
      /usr/local/go/src/bytes/buffer.go:187 +0xfc
  log/slog.(*commonHandler).handle()
      /usr/local/go/src/log/slog/handler.go:322 +0x6cc
  log/slog.(*JSONHandler).Handle()
      /usr/local/go/src/log/slog/json_handler.go:89 +0x5c
  log/slog.(*Logger).log()
      /usr/local/go/src/log/slog/logger.go:256 +0x178
  log/slog.(*Logger).Debug()
      /usr/local/go/src/log/slog/logger.go:199 +0xa3c
  github.com/LasseHels/frigg/grafana.(*DashboardPruner).prune()
      /Users/lasse.hels/Projects/frigg/grafana/dashboard_pruner.go:133 +0x974
  github.com/LasseHels/frigg/grafana.(*DashboardPruner).tick()
      /Users/lasse.hels/Projects/frigg/grafana/dashboard_pruner.go:101 +0x3c
  github.com/LasseHels/frigg/grafana.(*DashboardPruner).Start()
      /Users/lasse.hels/Projects/frigg/grafana/dashboard_pruner.go:85 +0x138
  github.com/LasseHels/frigg/frigg.(*Frigg).Start.gowrap1()
      /Users/lasse.hels/Projects/frigg/frigg/frigg.go:42 +0x58

Goroutine 21 (running) created at:
  testing.(*T).Run()
      /usr/local/go/src/testing/testing.go:1997 +0x6e0
  testing.runTests.func1()
      /usr/local/go/src/testing/testing.go:2477 +0x74
  testing.tRunner()
      /usr/local/go/src/testing/testing.go:1934 +0x164
  testing.runTests()
      /usr/local/go/src/testing/testing.go:2475 +0x734
  testing.(*M).Run()
      /usr/local/go/src/testing/testing.go:2337 +0xaf4
  main.main()
      _testmain.go:47 +0x100

Goroutine 665 (running) created at:
  github.com/LasseHels/frigg/frigg.(*Frigg).Start()
      /Users/lasse.hels/Projects/frigg/frigg/frigg.go:42 +0x9c
  github.com/LasseHels/frigg.run.func1()
      /Users/lasse.hels/Projects/frigg/main.go:85 +0x40
  golang.org/x/sync/errgroup.(*Group).add.func1()
      /Users/lasse.hels/go/pkg/mod/golang.org/x/sync@v0.15.0/errgroup/errgroup.go:128 +0xc0
==================
--- FAIL: TestFriggIntegration (10.96s)
    testing.go:1617: race detected during execution of test
FAIL
FAIL	github.com/LasseHels/frigg	12.162s
ok  	github.com/LasseHels/frigg/frigg	1.531s
ok  	github.com/LasseHels/frigg/frigg/handlers	1.532s
ok  	github.com/LasseHels/frigg/github	2.282s
ok  	github.com/LasseHels/frigg/grafana	1.875s
?   	github.com/LasseHels/frigg/integrationtest	[no test files]
?   	github.com/LasseHels/frigg/log	[no test files]
ok  	github.com/LasseHels/frigg/loki	6.635s
?   	github.com/LasseHels/frigg/server	[no test files]
FAIL
```