### PR TITLE
Don't run `Push / Publish / Image` action on tag pushes

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,13 @@
 name: Push
 
 on:
+  # Run on all pushes except tag pushes.
+  # See https://github.com/orgs/community/discussions/25615#discussioncomment-3248483.
   push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 
 jobs:
   test:


### PR DESCRIPTION
When a tag is pushed in the Frigg repository, two publish actions will run:
* `Push / Publish / Image`: https://github.com/LasseHels/frigg/actions/runs/19207364344.
* `Tag / Publish / Image`: https://github.com/LasseHels/frigg/actions/runs/19207364353.

The `Push / Publish / Image` attempts to push an image to Docker Hub with the commit SHA. This fails because an identical image has already been published from when the commit was pushed:
```
Error: failed to publish images: error publishing ko://github.com/LasseHels/frigg: PUT https://index.docker.io/v2/***/frigg/manifests/bf083dde1914524a25d128d41b3d7e8482f7cdd1: DENIED: requested access to the resource is denied; This tag is already assigned to an image in this repository and cannot be updated due to immutability settings. To push this image, use a different tag.
Error: Process completed with exit code 1.
```

This pull request updates the `Push / Publish / Image` action to not run on tag pushes.