### PR TITLE
Support Loki multi-tenancy

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,21 @@ grafana:
     # Required.
     endpoint: 'https://grafana.example.com'
 
+loki:
+    # Endpoint where Loki can be reached. This endpoint is used to query Grafana dashboard usage logs.
+    # Frigg automatically appends API path elements to this endpoint and expects the value of the configuration option
+    # to be the base URL of the Loki instance.
+    #
+    # The value of endpoint must be a valid URL according to Go's url.Parse() function.
+    #
+    # Required.
+    endpoint: 'https://loki.example.com'
+    # Tenant ID for multi-tenant Loki deployments. When set, Frigg includes the X-Scope-OrgID header in all Loki
+    # requests. See https://grafana.com/docs/loki/v3.6.x/operations/multi-tenancy.
+    #
+    # Optional.
+    tenant_id: 'my-tenant'
+
 prune:
   # If dry is set to true, the dashboard pruner will only log unused dashboards instead of deleting them (default: true).
   dry: true

--- a/frigg/config.go
+++ b/frigg/config.go
@@ -158,6 +158,7 @@ func (c *Config) Initialise(logger *slog.Logger, gatherer prometheus.Gatherer, s
 
 	lokiClient := loki.NewClient(loki.ClientOptions{
 		Endpoint:   c.Loki.Endpoint,
+		TenantID:   c.Loki.TenantID,
 		HTTPClient: httpClient,
 		Logger:     logger,
 	})

--- a/loki/client.go
+++ b/loki/client.go
@@ -20,12 +20,14 @@ type httpClient interface {
 
 type ClientOptions struct {
 	Endpoint   string
+	TenantID   string
 	HTTPClient httpClient
 	Logger     *slog.Logger
 }
 
 type Client struct {
 	endpoint string
+	tenantID string
 	client   httpClient
 	logger   *slog.Logger
 }
@@ -33,6 +35,7 @@ type Client struct {
 func NewClient(opts ClientOptions) *Client {
 	return &Client{
 		endpoint: opts.Endpoint,
+		tenantID: opts.TenantID,
 		client:   opts.HTTPClient,
 		logger:   opts.Logger,
 	}
@@ -100,6 +103,10 @@ func (c *Client) QueryRange(ctx context.Context, query string, start, end time.T
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating request")
+	}
+
+	if c.tenantID != "" {
+		req.Header.Set("X-Scope-OrgID", c.tenantID)
 	}
 
 	resp, err := c.client.Do(req)

--- a/loki/config.go
+++ b/loki/config.go
@@ -2,4 +2,5 @@ package loki
 
 type Config struct {
 	Endpoint string `yaml:"endpoint" validate:"required,url"`
+	TenantID string `yaml:"tenant_id"`
 }


### PR DESCRIPTION
This pull request updates Frigg to support Loki multi-tenancy. When multi-tenancy is enabled in a Loki instance, queries must set the `X-Scope-OrgID` HTTP header. Frigg's configuration now has an optional `loki.tenant_id` field that operators can use to set the `X-Scope-OrgID` header value. If `loki.tenant_id` is empty, the `X-Scope-OrgID` header is not set at all.

See https://grafana.com/docs/loki/v3.6.x/operations/multi-tenancy.

As an additional change, we add the missing `loki` section to Frigg's configuration documentation.