### PR TITLE
Set `release` when building Docker image

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -42,3 +42,4 @@ jobs:
         run: ko build . --bare --platform=${{ inputs.platforms }} --tags=${{ inputs.version }}
         env:
           KO_DOCKER_REPO: lassehels/frigg
+          GOFLAGS: -ldflags=-X=main.release=${{ inputs.version }}


### PR DESCRIPTION
Currently, Frigg's Docker image does not have the `release` field set, leading to incorrect log lines like this:
```json
{"time":"2025-12-07T10:50:10.095367262Z","level":"INFO","msg":"Starting Frigg","release":""}
```

This pull request updates Frigg's build process to set the `release` field.

I considered whether to set `release`'s value to `${{ inputs.version }}` or `${{ github.sha }}`. Setting it to `${{ github.sha }}` means that `release` is _always_ set to the commit's SHA, even for tag pushes. This is potentially confusing for those running Frigg; if I run `1.3.0` of Frigg's Docker image, why is the `release` field set to some commit SHA instead of the expected `1.3.0`? Setting it to `${{ inputs.version }}` means that `release` uses the tag version on tag pushes. This intuitively makes sense, but opens up for an edge case where a tag is updated to point to a new commit _after_ the image has been built. In this case, the image's `release` would be misleading. Given that Frigg uses immutable tags, this edge case cannot happen, and I think using the intuitive approach of `${{ inputs.version }}` makes the most sense.