### PR TITLE
Include dashboard title in emitted log lines

### DIFF
--- a/grafana/dashboard_pruner.go
+++ b/grafana/dashboard_pruner.go
@@ -127,7 +127,11 @@ func (d *DashboardPruner) prune(ctx context.Context) error {
 	var deleted []string
 
 	for _, dashboard := range all {
-		dashboardLogger := d.logger.With(slog.String("uid", dashboard.UID), slog.String("name", dashboard.Name))
+		dashboardLogger := d.logger.With(
+			slog.String("uid", dashboard.UID),
+			slog.String("name", dashboard.Name),
+			slog.String("title", dashboard.Title),
+		)
 		usage, isUsed := usedDashboards[dashboard.Key()]
 		if isUsed {
 			dashboardLogger.Debug(

--- a/grafana/dashboard_pruner_test.go
+++ b/grafana/dashboard_pruner_test.go
@@ -136,12 +136,14 @@ func TestDashboardPruner_Prune(t *testing.T) {
 						UID:       "cbf15242-fec5-4272-be50-1f83322ecf2c",
 						Name:      "dashboard1",
 						Namespace: "default",
+						Title:     "Dashboard 1",
 						Spec:      json.RawMessage(`{"title": "Dashboard 1"}`),
 					},
 					{
 						UID:       "50c3ea9d-d578-4c0f-a9c4-128577783c03",
 						Name:      "dashboard2",
 						Namespace: "default",
+						Title:     "Dashboard 2",
 						Spec:      json.RawMessage(`{"title": "Dashboard 2"}`),
 					},
 				}, nil
@@ -178,8 +180,8 @@ func TestDashboardPruner_Prune(t *testing.T) {
 		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards","dry":false,"namespace":"default"}
 {"level":"INFO","msg":"Found all Grafana dashboards","dry":false,"namespace":"default","count":2}
 {"level":"INFO","msg":"Found used Grafana dashboards","dry":false,"namespace":"default","count":2}
-{"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"namespace":"default","uid":"cbf15242-fec5-4272-be50-1f83322ecf2c","name":"dashboard1","reads":10,"users":2,"range":"24h0m0s"}
-{"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"namespace":"default","uid":"50c3ea9d-d578-4c0f-a9c4-128577783c03","name":"dashboard2","reads":5,"users":1,"range":"24h0m0s"}
+{"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"namespace":"default","uid":"cbf15242-fec5-4272-be50-1f83322ecf2c","name":"dashboard1","title":"Dashboard 1","reads":10,"users":2,"range":"24h0m0s"}
+{"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"namespace":"default","uid":"50c3ea9d-d578-4c0f-a9c4-128577783c03","name":"dashboard2","title":"Dashboard 2","reads":5,"users":1,"range":"24h0m0s"}
 {"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"namespace":"default","deleted_count":0,"deleted_dashboards":""}
 `
 		assert.Equal(t, expectedLogs, logs.String())
@@ -197,18 +199,21 @@ func TestDashboardPruner_Prune(t *testing.T) {
 						UID:       "a22d74c5-83c5-4cd5-88a9-2af0544bdac2",
 						Name:      "dashboard1",
 						Namespace: "default",
+						Title:     "Dashboard 1",
 						Spec:      json.RawMessage(`{"title": "Dashboard 1"}`),
 					},
 					{
 						UID:       "441c13ff-dc1d-4d90-9984-b15532e626ff",
 						Name:      "dashboard2",
 						Namespace: "default",
+						Title:     "Dashboard 2",
 						Spec:      json.RawMessage(`{"title": "Dashboard 2"}`),
 					},
 					{
 						UID:       "541517b1-3e42-497b-8038-25905320396e",
 						Name:      "dashboard3",
 						Namespace: "default",
+						Title:     "Dashboard 3",
 						Spec:      json.RawMessage(`{"title": "Dashboard 3"}`),
 					},
 				}, nil
@@ -260,11 +265,11 @@ func TestDashboardPruner_Prune(t *testing.T) {
 		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards","dry":false,"namespace":"default"}
 {"level":"INFO","msg":"Found all Grafana dashboards","dry":false,"namespace":"default","count":3}
 {"level":"INFO","msg":"Found used Grafana dashboards","dry":false,"namespace":"default","count":1}
-{"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"namespace":"default","uid":"a22d74c5-83c5-4cd5-88a9-2af0544bdac2","name":"dashboard1","reads":10,"users":2,"range":"24h0m0s"}
-{"level":"INFO","msg":"Deleting unused dashboard","dry":false,"namespace":"default","uid":"441c13ff-dc1d-4d90-9984-b15532e626ff","name":"dashboard2","raw_json":"{\"title\": \"Dashboard 2\"}"}
-{"level":"INFO","msg":"Deleted unused dashboard","dry":false,"namespace":"default","uid":"441c13ff-dc1d-4d90-9984-b15532e626ff","name":"dashboard2","raw_json":"{\"title\": \"Dashboard 2\"}"}
-{"level":"INFO","msg":"Deleting unused dashboard","dry":false,"namespace":"default","uid":"541517b1-3e42-497b-8038-25905320396e","name":"dashboard3","raw_json":"{\"title\": \"Dashboard 3\"}"}
-{"level":"INFO","msg":"Deleted unused dashboard","dry":false,"namespace":"default","uid":"541517b1-3e42-497b-8038-25905320396e","name":"dashboard3","raw_json":"{\"title\": \"Dashboard 3\"}"}
+{"level":"DEBUG","msg":"Skipping used dashboard","dry":false,"namespace":"default","uid":"a22d74c5-83c5-4cd5-88a9-2af0544bdac2","name":"dashboard1","title":"Dashboard 1","reads":10,"users":2,"range":"24h0m0s"}
+{"level":"INFO","msg":"Deleting unused dashboard","dry":false,"namespace":"default","uid":"441c13ff-dc1d-4d90-9984-b15532e626ff","name":"dashboard2","title":"Dashboard 2","raw_json":"{\"title\": \"Dashboard 2\"}"}
+{"level":"INFO","msg":"Deleted unused dashboard","dry":false,"namespace":"default","uid":"441c13ff-dc1d-4d90-9984-b15532e626ff","name":"dashboard2","title":"Dashboard 2","raw_json":"{\"title\": \"Dashboard 2\"}"}
+{"level":"INFO","msg":"Deleting unused dashboard","dry":false,"namespace":"default","uid":"541517b1-3e42-497b-8038-25905320396e","name":"dashboard3","title":"Dashboard 3","raw_json":"{\"title\": \"Dashboard 3\"}"}
+{"level":"INFO","msg":"Deleted unused dashboard","dry":false,"namespace":"default","uid":"541517b1-3e42-497b-8038-25905320396e","name":"dashboard3","title":"Dashboard 3","raw_json":"{\"title\": \"Dashboard 3\"}"}
 {"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":false,"namespace":"default","deleted_count":2,"deleted_dashboards":"default/dashboard2, default/dashboard3"}
 `
 		assert.Equal(t, expectedLogs, logs.String())
@@ -282,12 +287,14 @@ func TestDashboardPruner_Prune(t *testing.T) {
 						UID:       "3f02045e-5d94-4dbe-94e8-1353b1aede29",
 						Name:      "dashboard1",
 						Namespace: "blueberry",
+						Title:     "Dashboard 1",
 						Spec:      json.RawMessage(`{"title": "Dashboard 1"}`),
 					},
 					{
 						UID:       "952e2e84-2515-4f7c-b965-151671b3300c",
 						Name:      "dashboard2",
 						Namespace: "blueberry",
+						Title:     "Dashboard 2",
 						Spec:      json.RawMessage(`{"title": "Dashboard 2"}`),
 					},
 				}, nil
@@ -329,8 +336,8 @@ func TestDashboardPruner_Prune(t *testing.T) {
 		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards","dry":true,"namespace":"blueberry"}
 {"level":"INFO","msg":"Found all Grafana dashboards","dry":true,"namespace":"blueberry","count":2}
 {"level":"INFO","msg":"Found used Grafana dashboards","dry":true,"namespace":"blueberry","count":1}
-{"level":"INFO","msg":"Found unused dashboard, skipping deletion due to dry run","dry":true,"namespace":"blueberry","uid":"3f02045e-5d94-4dbe-94e8-1353b1aede29","name":"dashboard1"}
-{"level":"INFO","msg":"Found unused dashboard, skipping deletion due to dry run","dry":true,"namespace":"blueberry","uid":"952e2e84-2515-4f7c-b965-151671b3300c","name":"dashboard2"}
+{"level":"INFO","msg":"Found unused dashboard, skipping deletion due to dry run","dry":true,"namespace":"blueberry","uid":"3f02045e-5d94-4dbe-94e8-1353b1aede29","name":"dashboard1","title":"Dashboard 1"}
+{"level":"INFO","msg":"Found unused dashboard, skipping deletion due to dry run","dry":true,"namespace":"blueberry","uid":"952e2e84-2515-4f7c-b965-151671b3300c","name":"dashboard2","title":"Dashboard 2"}
 {"level":"INFO","msg":"Finished pruning Grafana dashboards","dry":true,"namespace":"blueberry","deleted_count":0,"deleted_dashboards":""}
 `
 		assert.Equal(t, expectedLogs, logs.String())
@@ -368,9 +375,10 @@ func TestDashboardPruner_Prune(t *testing.T) {
 			allDashboards: func(_ context.Context, _ string) ([]Dashboard, error) {
 				return []Dashboard{
 					{
-						UID:  "dashboard1",
-						Name: "Dashboard 1",
-						Spec: json.RawMessage(`{"title": "Dashboard 1"}`),
+						UID:   "dashboard1",
+						Name:  "Dashboard 1",
+						Title: "Dashboard 1",
+						Spec:  json.RawMessage(`{"title": "Dashboard 1"}`),
 					},
 				}, nil
 			},
@@ -410,12 +418,14 @@ func TestDashboardPruner_Prune(t *testing.T) {
 						UID:       "dashboard1",
 						Name:      "Dashboard 1",
 						Namespace: "default",
+						Title:     "Dashboard 1",
 						Spec:      json.RawMessage(`{"title": "Dashboard 1"}`),
 					},
 					{
 						UID:       "dashboard2",
 						Name:      "Dashboard 2",
 						Namespace: "default",
+						Title:     "Dashboard 2",
 						Spec:      json.RawMessage(`{"title": "Dashboard 2"}`),
 					},
 				}, nil
@@ -452,7 +462,7 @@ func TestDashboardPruner_Prune(t *testing.T) {
 		expectedLogs := `{"level":"INFO","msg":"Pruning Grafana dashboards","dry":false,"namespace":"default"}
 {"level":"INFO","msg":"Found all Grafana dashboards","dry":false,"namespace":"default","count":2}
 {"level":"INFO","msg":"Found used Grafana dashboards","dry":false,"namespace":"default","count":0}
-{"level":"INFO","msg":"Deleting unused dashboard","dry":false,"namespace":"default","uid":"dashboard1","name":"Dashboard 1","raw_json":"{\"title\": \"Dashboard 1\"}"}
+{"level":"INFO","msg":"Deleting unused dashboard","dry":false,"namespace":"default","uid":"dashboard1","name":"Dashboard 1","title":"Dashboard 1","raw_json":"{\"title\": \"Dashboard 1\"}"}
 `
 		assert.Equal(t, expectedLogs, logs.String())
 	})

--- a/integration_test.go
+++ b/integration_test.go
@@ -109,7 +109,7 @@ func TestFriggIntegration(t *testing.T) {
 		t,
 		logs,
 		`"msg":"Deleted unused dashboard","release":"integration-test","dry":false,"namespace":"default","uid":`+
-			`"qXQslCwCEssfGqKRa9patJDjtRbOf5XNGwOXXjdRnx0X","name":"ignoreduserdashboard",`+
+			`"qXQslCwCEssfGqKRa9patJDjtRbOf5XNGwOXXjdRnx0X","name":"ignoreduserdashboard","title":"ignoreduserdashboard",`+
 			`"raw_json":"{\"editable\":false,\"schemaVersion\":42,\"time\":{\"from\":\"now-6h\",\"to\":\"now\"},\`+
 			`"timepicker\":{},\"timezone\":\"browser\",\"title\":\"ignoreduserdashboard\"}"}`,
 	)
@@ -117,7 +117,7 @@ func TestFriggIntegration(t *testing.T) {
 		t,
 		logs,
 		`"msg":"Deleted unused dashboard","release":"integration-test","dry":false,"namespace":"default","uid":`+
-			`"mspoU2EJfAXM0lQ8bBBUha0AszqQEKUKMjzu4Gc3rnEX","name":"unuseddashboard",`+
+			`"mspoU2EJfAXM0lQ8bBBUha0AszqQEKUKMjzu4Gc3rnEX","name":"unuseddashboard","title":"unuseddashboard",`+
 			`"raw_json":"{\"editable\":false,\"schemaVersion\":42,\"time\":{\"from\":\"now-6h\",\"to\":\"now\"},\`+
 			`"timepicker\":{},\"timezone\":\"browser\",\"title\":\"unuseddashboard\"}"}`,
 	)
@@ -132,8 +132,9 @@ func TestFriggIntegration(t *testing.T) {
 		logs,
 		`"msg":"Deleted unused dashboard","release":"integration-test","dry":false,"namespace":"org-2",`+
 			`"uid":"JfROTruBNXvUjXF8aD455yc2sRiB397AL6Pscl8QChsX","name":"purpleunuseddashboard",`+
-			`"raw_json":"{\"editable\":false,\"schemaVersion\":42,\"time\":{\"from\":\"now-6h\",\"to\":\"now\"},`+
-			`\"timepicker\":{},\"timezone\":\"browser\",\"title\":\"purpleunuseddashboard\"}"}`,
+			`"title":"purpleunuseddashboard","raw_json":"{\"editable\":false,\"schemaVersion\":42,`+
+			`\"time\":{\"from\":\"now-6h\",\"to\":\"now\"},\"timepicker\":{},\"timezone\":\"browser\",`+
+			`\"title\":\"purpleunuseddashboard\"}"}`,
 	)
 	assert.Contains(
 		t,


### PR DESCRIPTION
Frigg currently emits dashboard log lines like this:
```json
{
  "time": "2025-12-07T10:50:27.853571641Z",
  "level": "INFO",
  "msg": "Found unused dashboard, skipping deletion due to dry run",
  "dry": true,
  "namespace": "default",
  "uid": "vwlXJoYR1VudoOkwX8natmjozKTukX4I9NQC3n5WrfcX",
  "name": "ff635a025bcfea7bc3dd4f508990a3e9"
}
```

This makes it extremely difficult to tell what dashboard is being processes.

With the changes in this pull request, Frigg now includes dashboard `title` in the emitted log line. This should make it easier to identify the dashboards.