### PR TITLE
Skip provisioned dashboards

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ When gauging dashboard usage, Frigg counts two activities as a dashboard "view":
 Any dashboard that has been viewed at least once within the configured `prune.period` (see [Configuration](#configuration))
 is considered used and will not be deleted.
 
+> [!IMPORTANT]
+> Frigg will never delete a [provisioned](https://grafana.com/docs/grafana/v12.2/administration/provisioning/#dashboards) dashboard.
+
 ## Configuration
 
 Frigg is configured using a configuration file and a secrets file. The paths to these files are provided using the

--- a/integration_test.go
+++ b/integration_test.go
@@ -61,6 +61,7 @@ func TestFriggIntegration(t *testing.T) {
 			env.grafana.AssertDashboardExists(collect, env.apiKey, "default", "useddashboardapi")
 			env.grafana.AssertDashboardDoesNotExist(collect, env.apiKey, "default", "ignoreduserdashboard")
 			env.grafana.AssertDashboardDoesNotExist(collect, env.purpleKey, env.purpleNamespace, "purpleunuseddashboard")
+			env.grafana.AssertDashboardExists(collect, env.apiKey, "default", "provisioneddashboard")
 		}, time.Second*10, time.Millisecond*100)
 
 		requests := env.github.Requests()

--- a/integrationtest/grafana.go
+++ b/integrationtest/grafana.go
@@ -43,6 +43,13 @@ func NewGrafana(t *testing.T, logConsumers ...testcontainers.LogConsumer) *Grafa
 			// https://grafana.com/docs/grafana/v12.0/setup-grafana/configure-grafana/#router_logging.
 			"GF_SERVER_ROUTER_LOGGING": "true",
 		},
+		Files: []testcontainers.ContainerFile{
+			{
+				HostFilePath:      "testdata/provisioning/dashboards",
+				ContainerFilePath: "/etc/grafana/provisioning/dashboards",
+				FileMode:          0o755,
+			},
+		},
 		WaitingFor: wait.ForAll(
 			wait.ForExposedPort(),
 			wait.ForHTTP("/api/health"),

--- a/testdata/provisioning/dashboards/dashboard.yaml
+++ b/testdata/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 10
+    allowUiUpdates: false
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/testdata/provisioning/dashboards/provisioneddashboard.json
+++ b/testdata/provisioning/dashboards/provisioneddashboard.json
@@ -1,0 +1,12 @@
+{
+  "uid": "provisioneddashboard",
+  "editable": false,
+  "schemaVersion": 42,
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "provisioneddashboard"
+}


### PR DESCRIPTION
Currently, Frigg attempts to delete all unused dashboards, even if the dashboard is [provisioned](https://grafana.com/docs/grafana/v12.2/administration/provisioning/#dashboards). Attempting to delete a provisioned dashboard fails with a `400 Bad Request`:
```
provisioned dashboard cannot be deleted
```

With the changes in this pull request, Frigg will now skip provisioned dashboards.

As a minor change, we also update a couple of `errors.Wrap()` to the more idiomatic `fmt.Errorf()`.