### PR TITLE
Add `AGENTS.md` and `CLAUDE.md`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+README.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+README.md

--- a/README.md
+++ b/README.md
@@ -222,3 +222,8 @@ If `FRIGG_HOST` is set to `example.com`, Frigg will use `example.com` as the ser
 
 > [!NOTE]
 > The secrets file does not support environment variable expansion for security reasons.
+
+## Linting & Testing
+
+Use `make lint` and `make test-all` to verify the correctness of changes made. Frigg uses
+[golangci-lint](https://golangci-lint.run/docs/) for linting.


### PR DESCRIPTION
This pull request adds `AGENTS.md` and `CLAUDE.md` files. We add both because Claude Code does not yet support `AGENTS.md`. See https://github.com/anthropics/claude-code/issues/6235.

Both files are symlinks of `README.md`. I'm curious to try out how well this works. I always want agents to know everything that humans should know about the project, and I can't yet think of any information that _only_ agents should know. With the symlink, these two copora of information are always identical.