### PR TITLE
Update golangci-lint from `v2.4.0` to `v2.7.2`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Lint
-        uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
+        uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.4.0
+          version: v2.7.2
           args: --timeout=30m --verbose

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -143,6 +143,8 @@ linters:
           disabled: true
         - name: package-comments
           disabled: true
+        - name: unsecure-url-scheme
+          disabled: true
     rowserrcheck:
       packages:
         - github.com/jmoiron/sqlx

--- a/github/repository.go
+++ b/github/repository.go
@@ -14,7 +14,7 @@ type Config struct {
 	Repository Repository `yaml:"repository" validate:"required"`
 	Branch     string     `yaml:"branch" validate:"required"`
 	Directory  string     `yaml:"directory" validate:"required"`
-	APIURL     string     `yaml:"api_url" validate:"omitempty,url"` //nolint:revive // omitempty is valid for validator
+	APIURL     string     `yaml:"api_url" validate:"omitempty,url"`
 }
 
 // Repository represents a GitHub repository in "owner/repo" format.

--- a/main.go
+++ b/main.go
@@ -28,13 +28,6 @@ const flagConfigFile = "config.file"
 const flagSecretsFile = "secrets.file"
 
 func main() {
-	os.Exit(start())
-}
-
-func start() int {
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
-	defer stop()
-
 	var configPath, secretsPath string
 	flag.StringVar(
 		&configPath,
@@ -49,6 +42,13 @@ func start() int {
 		"Path to Frigg's secrets file. The file's extension must be .json, .yml or .yaml (required)",
 	)
 	flag.Parse()
+
+	os.Exit(start(configPath, secretsPath))
+}
+
+func start(configPath, secretsPath string) int {
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, syscall.SIGINT)
+	defer stop()
 
 	if err := run(ctx, configPath, secretsPath, os.Stdout); err != nil {
 		fmt.Println(err.Error())


### PR DESCRIPTION
Update [golangci-lint-action](https://github.com/golangci/golangci-lint-action) from [`v8.0.0`](https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0) to [`v9.2.0`](https://github.com/golangci/golangci-lint-action/releases/tag/v9.2.0).

Update [golangci-lint](https://github.com/golangci/golangci-lint) from [`v2.4.0`](https://github.com/golangci/golangci-lint/releases/tag/v2.4.0) to [`v2.7.2`](https://github.com/golangci/golangci-lint/releases/tag/v2.7.2).