### PR TITLE
Page through all logs when querying Loki

### DIFF
--- a/frigg/config.go
+++ b/frigg/config.go
@@ -161,6 +161,7 @@ func (c *Config) Initialise(logger *slog.Logger, gatherer prometheus.Gatherer, s
 		TenantID:   c.Loki.TenantID,
 		HTTPClient: httpClient,
 		Logger:     logger,
+		Limit:      100,
 	})
 
 	grafanaURL := mustParseURL(c.Grafana.Endpoint)

--- a/loki/client.go
+++ b/loki/client.go
@@ -96,7 +96,7 @@ func (c *Client) QueryRange(ctx context.Context, query string, start, end time.T
 	currentStart := start
 
 	for {
-		logs, err := c.queryRangePage(ctx, query, currentStart, end)
+		logs, maxTimestamp, err := c.queryRangePage(ctx, query, currentStart, end)
 		if err != nil {
 			return nil, err
 		}
@@ -108,24 +108,24 @@ func (c *Client) QueryRange(ctx context.Context, query string, start, end time.T
 			break
 		}
 
-		// Advance start time to 1 nanosecond after the last log's timestamp.
+		// Advance start time to 1 nanosecond after the maximum timestamp in the page.
 		//
 		// Unlikely edge case: a count of logs greater than the configured limit share the exact same nanosecond
 		// timestamp. For example, if the limit is 1000 and there are 1500 logs with timestamp T, the first query will
 		// return 1000 logs with timestamp T, and the next query will start at T + 1 nanosecond, missing the remaining
 		// 500 logs with timestamp T.
-		lastLog := logs[len(logs)-1]
-		currentStart = lastLog.Timestamp().Add(time.Nanosecond)
+		currentStart = maxTimestamp.Add(time.Nanosecond)
 	}
 
 	return allLogs, nil
 }
 
 // queryRangePage executes a single query_range request to Loki.
-func (c *Client) queryRangePage(ctx context.Context, query string, start, end time.Time) ([]Log, error) {
+// Returns the logs, the maximum timestamp among all logs (for pagination), and any error.
+func (c *Client) queryRangePage(ctx context.Context, query string, start, end time.Time) ([]Log, time.Time, error) {
 	u, err := url.Parse(fmt.Sprintf("%s/loki/api/v1/query_range", c.endpoint))
 	if err != nil {
-		return nil, fmt.Errorf("parsing URL: %w", err)
+		return nil, time.Time{}, fmt.Errorf("parsing URL: %w", err)
 	}
 
 	q := u.Query()
@@ -138,7 +138,7 @@ func (c *Client) queryRangePage(ctx context.Context, query string, start, end ti
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), http.NoBody)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, time.Time{}, fmt.Errorf("creating request: %w", err)
 	}
 
 	if c.tenantID != "" {
@@ -147,7 +147,7 @@ func (c *Client) queryRangePage(ctx context.Context, query string, start, end ti
 
 	resp, err := c.client.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("executing request: %w", err)
+		return nil, time.Time{}, fmt.Errorf("executing request: %w", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
@@ -155,41 +155,46 @@ func (c *Client) queryRangePage(ctx context.Context, query string, start, end ti
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading response body: %w", err)
+		return nil, time.Time{}, fmt.Errorf("reading response body: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
+		return nil, time.Time{}, fmt.Errorf("unexpected status code: %d, body: %s", resp.StatusCode, string(body))
 	}
 
 	var response queryRangeResponse
 	if err := json.Unmarshal(body, &response); err != nil {
-		return nil, fmt.Errorf("unmarshalling response: %w", err)
+		return nil, time.Time{}, fmt.Errorf("unmarshalling response: %w", err)
 	}
 
 	if response.Status != "success" {
-		return nil, fmt.Errorf("query failed with status: %s", response.Status)
+		return nil, time.Time{}, fmt.Errorf("query failed with status: %s", response.Status)
 	}
 
 	var logs []Log
+	var maxTimestamp time.Time
 	for _, result := range response.Data.Result {
 		for _, value := range result.Values {
 			if len(value) != 2 {
-				return nil, fmt.Errorf("invalid value format in Loki response: %v", value)
+				return nil, time.Time{}, fmt.Errorf("invalid value format in Loki response: %v", value)
 			}
 
 			nanoseconds, err := strconv.ParseInt(value[0], 10, 64)
 			if err != nil {
-				return nil, fmt.Errorf("parsing timestamp %q: %w", value[0], err)
+				return nil, time.Time{}, fmt.Errorf("parsing timestamp %q: %w", value[0], err)
 			}
 
 			timestamp := time.Unix(0, nanoseconds).UTC()
 			message := value[1]
+
+			if timestamp.After(maxTimestamp) {
+				maxTimestamp = timestamp
+			}
 
 			l := NewLog(timestamp, message, result.Stream)
 			logs = append(logs, l)
 		}
 	}
 
-	return logs, nil
+	return logs, maxTimestamp, nil
 }

--- a/loki/client.go
+++ b/loki/client.go
@@ -86,8 +86,7 @@ type queryRangeResponse struct {
 	Data   queryRangeData `json:"data"`
 }
 
-// QueryRange queries Loki logs over a range of time and automatically paginates
-// through all results.
+// QueryRange queries Loki logs over a range of time and automatically paginates through all results.
 //
 // See [Loki API documentation].
 //

--- a/loki/client_integration_test.go
+++ b/loki/client_integration_test.go
@@ -114,7 +114,7 @@ func TestClient_QueryRange_Integration(t *testing.T) {
 			var err error
 			logs, err = client.QueryRange(t.Context(), query, queryStart, queryEnd)
 			assert.NoError(collect, err)
-			assert.Len(collect, logs, 4, "Expected exactly 4 logs, got %d", len(logs))
+			assert.Len(collect, logs, 4)
 		}, 10*time.Second, 50*time.Millisecond)
 
 		seenMessages := make(map[string]int)
@@ -122,11 +122,11 @@ func TestClient_QueryRange_Integration(t *testing.T) {
 			seenMessages[log.Message()]++
 		}
 
-		assert.Len(t, seenMessages, 4, "Expected 4 unique log messages (indicates duplicates or missed logs)")
-		assert.Equal(t, 1, seenMessages["log-A-1"], "log-A-1 should appear exactly once")
-		assert.Equal(t, 1, seenMessages["log-A-2"], "log-A-2 should appear exactly once")
-		assert.Equal(t, 1, seenMessages["log-B-1"], "log-B-1 should appear exactly once")
-		assert.Equal(t, 1, seenMessages["log-B-2"], "log-B-2 should appear exactly once")
+		assert.Len(t, seenMessages, 4)
+		assert.Equal(t, 1, seenMessages["log-A-1"])
+		assert.Equal(t, 1, seenMessages["log-A-2"])
+		assert.Equal(t, 1, seenMessages["log-B-1"])
+		assert.Equal(t, 1, seenMessages["log-B-2"])
 
 		timestampByMessage := make(map[string]time.Time)
 		for _, log := range logs {

--- a/loki/client_integration_test.go
+++ b/loki/client_integration_test.go
@@ -49,6 +49,7 @@ func TestClient_QueryRange_Integration(t *testing.T) {
 		Endpoint:   fmt.Sprintf("http://%s", lokiContainer.Host()),
 		HTTPClient: http.DefaultClient,
 		Logger:     slog.Default(),
+		Limit:      100,
 	})
 
 	query := `{app="frigg-test",env="integration"} | logfmt`
@@ -62,12 +63,11 @@ func TestClient_QueryRange_Integration(t *testing.T) {
 		assert.Len(collect, logs, 2, "Expected to get exactly 2 logs within the query range")
 	}, 10*time.Second, 50*time.Millisecond, "Timed out waiting for logs to be queryable")
 
-	assert.Equal(t, "Second log entry in range", logs[0].Message())
-	assert.Equal(t, `traceID=123456 msg="First log in range"`, logs[1].Message())
-	assert.Equal(t, secondTimestamp, logs[0].Timestamp())
-	assert.Equal(t, firstTimestamp, logs[1].Timestamp())
+	assert.Equal(t, `traceID=123456 msg="First log in range"`, logs[0].Message())
+	assert.Equal(t, "Second log entry in range", logs[1].Message())
+	assert.Equal(t, firstTimestamp, logs[0].Timestamp())
+	assert.Equal(t, secondTimestamp, logs[1].Timestamp())
 
-	assert.Equal(t, map[string]string{"app": "frigg-test", "env": "integration"}, logs[0].Stream())
 	assert.Equal(
 		t,
 		map[string]string{
@@ -76,8 +76,56 @@ func TestClient_QueryRange_Integration(t *testing.T) {
 			"traceID": "123456",
 			"msg":     "First log in range",
 		},
-		logs[1].Stream(),
+		logs[0].Stream(),
 	)
+	assert.Equal(t, map[string]string{"app": "frigg-test", "env": "integration"}, logs[1].Stream())
+}
+
+// TestClient_QueryRange_SameTimestamp_Integration documents a known pagination limitation: if more
+// logs share the exact same nanosecond timestamp than the configured limit, logs beyond the first
+// `limit` at that timestamp will be missed.
+func TestClient_QueryRange_SameTimestamp_Integration(t *testing.T) {
+	integrationtest.SkipIfShort(t)
+
+	lokiContainer := integrationtest.NewLoki(t)
+
+	now := time.Now().UTC()
+	sharedTimestamp := now.Add(-30 * time.Minute)
+	queryStart := now.Add(-60 * time.Minute)
+	queryEnd := now
+
+	labels := map[string]string{"app": "frigg-same-ts", "env": "integration"}
+
+	// Push 5 logs with the exact same timestamp.
+	for i := range 5 {
+		pushLogEntry(t, lokiContainer.Host(), sharedTimestamp, fmt.Sprintf("log entry %d", i+1), labels)
+	}
+
+	// Configure client with a limit lower than the number of logs.
+	client := loki.NewClient(loki.ClientOptions{
+		Endpoint:   fmt.Sprintf("http://%s", lokiContainer.Host()),
+		HTTPClient: http.DefaultClient,
+		Logger:     slog.Default(),
+		Limit:      2,
+	})
+
+	query := `{app="frigg-same-ts",env="integration"}`
+
+	var logs []loki.Log
+	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+		var err error
+		logs, err = client.QueryRange(t.Context(), query, queryStart, queryEnd)
+		assert.NoError(collect, err)
+		// We expect to get only 2 logs due to the pagination limitation.
+		// All 5 logs share the same timestamp, so after fetching 2, we advance
+		// the start time by 1ns and miss the remaining 3.
+		assert.Len(collect, logs, 2)
+	}, 10*time.Second, 50*time.Millisecond)
+
+	assert.Equal(t, "log entry 1", logs[0].Message())
+	assert.Equal(t, "log entry 2", logs[1].Message())
+	assert.Equal(t, sharedTimestamp, logs[0].Timestamp())
+	assert.Equal(t, sharedTimestamp, logs[1].Timestamp())
 }
 
 func pushLogEntry(t *testing.T, lokiAddress string, timestamp time.Time, message string, labels map[string]string) {

--- a/loki/client_integration_test.go
+++ b/loki/client_integration_test.go
@@ -32,53 +32,112 @@ func TestClient_QueryRange_Integration(t *testing.T) {
 	lokiContainer := integrationtest.NewLoki(t)
 
 	now := time.Now().UTC()
-	firstTimestamp := now.Add(-30 * time.Minute)
-	secondTimestamp := now.Add(-40 * time.Minute)
-	beforeRange := now.Add(-2 * time.Hour)
 	queryStart := now.Add(-60 * time.Minute)
 	queryEnd := now
 
-	labels := map[string]string{"app": "frigg-test", "env": "integration"}
+	t.Run("single stream with logfmt parsing", func(t *testing.T) {
+		firstTimestamp := now.Add(-30 * time.Minute)
+		secondTimestamp := now.Add(-40 * time.Minute)
+		beforeRange := now.Add(-2 * time.Hour)
 
-	pushLogEntry(t, lokiContainer.Host(), beforeRange, "Log entry before query range", labels)
+		labels := map[string]string{"app": "frigg-test", "env": "integration"}
 
-	pushLogEntry(t, lokiContainer.Host(), firstTimestamp, `traceID=123456 msg="First log in range"`, labels)
-	pushLogEntry(t, lokiContainer.Host(), secondTimestamp, "Second log entry in range", labels)
+		pushLogEntry(t, lokiContainer.Host(), beforeRange, "Log entry before query range", labels)
+		pushLogEntry(t, lokiContainer.Host(), firstTimestamp, `traceID=123456 msg="First log in range"`, labels)
+		pushLogEntry(t, lokiContainer.Host(), secondTimestamp, "Second log entry in range", labels)
 
-	client := loki.NewClient(loki.ClientOptions{
-		Endpoint:   fmt.Sprintf("http://%s", lokiContainer.Host()),
-		HTTPClient: http.DefaultClient,
-		Logger:     slog.Default(),
-		Limit:      100,
+		client := loki.NewClient(loki.ClientOptions{
+			Endpoint:   fmt.Sprintf("http://%s", lokiContainer.Host()),
+			HTTPClient: http.DefaultClient,
+			Logger:     slog.Default(),
+			Limit:      100,
+		})
+
+		query := `{app="frigg-test",env="integration"} | logfmt`
+
+		var logs []loki.Log
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			var err error
+			logs, err = client.QueryRange(t.Context(), query, queryStart, queryEnd)
+			assert.NoError(collect, err)
+			assert.Len(collect, logs, 2, "Expected to get exactly 2 logs within the query range")
+		}, 10*time.Second, 50*time.Millisecond, "Timed out waiting for logs to be queryable")
+
+		assert.Equal(t, `traceID=123456 msg="First log in range"`, logs[0].Message())
+		assert.Equal(t, "Second log entry in range", logs[1].Message())
+		assert.Equal(t, firstTimestamp, logs[0].Timestamp())
+		assert.Equal(t, secondTimestamp, logs[1].Timestamp())
+
+		assert.Equal(
+			t,
+			map[string]string{
+				"app":     "frigg-test",
+				"env":     "integration",
+				"traceID": "123456",
+				"msg":     "First log in range",
+			},
+			logs[0].Stream(),
+		)
+		assert.Equal(t, map[string]string{"app": "frigg-test", "env": "integration"}, logs[1].Stream())
 	})
 
-	query := `{app="frigg-test",env="integration"} | logfmt`
+	// This subtest verifies that pagination works correctly with multiple streams that have interleaved timestamps.
+	// Loki groups logs by stream in its response, so the pagination cursor must use the maximum timestamp across all
+	// streams, not the last log in iteration order.
+	t.Run("multi-stream pagination", func(t *testing.T) {
+		streamA := map[string]string{"app": "frigg-multistream", "instance": "a"}
+		streamB := map[string]string{"app": "frigg-multistream", "instance": "b"}
 
-	// Poll until logs are available or timeout is reached
-	var logs []loki.Log
-	assert.EventuallyWithT(t, func(collect *assert.CollectT) {
-		var err error
-		logs, err = client.QueryRange(t.Context(), query, queryStart, queryEnd)
-		assert.NoError(collect, err)
-		assert.Len(collect, logs, 2, "Expected to get exactly 2 logs within the query range")
-	}, 10*time.Second, 50*time.Millisecond, "Timed out waiting for logs to be queryable")
+		// Push logs with interleaved timestamps across two streams.
+		// Chronological order: T=50, T=45, T=40, T=30 (minutes ago).
+		t50 := now.Add(-50 * time.Minute)
+		t45 := now.Add(-45 * time.Minute)
+		t40 := now.Add(-40 * time.Minute)
+		t30 := now.Add(-30 * time.Minute)
 
-	assert.Equal(t, `traceID=123456 msg="First log in range"`, logs[0].Message())
-	assert.Equal(t, "Second log entry in range", logs[1].Message())
-	assert.Equal(t, firstTimestamp, logs[0].Timestamp())
-	assert.Equal(t, secondTimestamp, logs[1].Timestamp())
+		pushLogEntry(t, lokiContainer.Host(), t50, "log-A-1", streamA)
+		pushLogEntry(t, lokiContainer.Host(), t30, "log-A-2", streamA)
+		pushLogEntry(t, lokiContainer.Host(), t45, "log-B-1", streamB)
+		pushLogEntry(t, lokiContainer.Host(), t40, "log-B-2", streamB)
 
-	assert.Equal(
-		t,
-		map[string]string{
-			"app":     "frigg-test",
-			"env":     "integration",
-			"traceID": "123456",
-			"msg":     "First log in range",
-		},
-		logs[0].Stream(),
-	)
-	assert.Equal(t, map[string]string{"app": "frigg-test", "env": "integration"}, logs[1].Stream())
+		client := loki.NewClient(loki.ClientOptions{
+			Endpoint:   fmt.Sprintf("http://%s", lokiContainer.Host()),
+			HTTPClient: http.DefaultClient,
+			Logger:     slog.Default(),
+			Limit:      2,
+		})
+
+		query := `{app="frigg-multistream"}`
+
+		var logs []loki.Log
+		assert.EventuallyWithT(t, func(collect *assert.CollectT) {
+			var err error
+			logs, err = client.QueryRange(t.Context(), query, queryStart, queryEnd)
+			assert.NoError(collect, err)
+			assert.Len(collect, logs, 4, "Expected exactly 4 logs, got %d", len(logs))
+		}, 10*time.Second, 50*time.Millisecond)
+
+		seenMessages := make(map[string]int)
+		for _, log := range logs {
+			seenMessages[log.Message()]++
+		}
+
+		assert.Len(t, seenMessages, 4, "Expected 4 unique log messages (indicates duplicates or missed logs)")
+		assert.Equal(t, 1, seenMessages["log-A-1"], "log-A-1 should appear exactly once")
+		assert.Equal(t, 1, seenMessages["log-A-2"], "log-A-2 should appear exactly once")
+		assert.Equal(t, 1, seenMessages["log-B-1"], "log-B-1 should appear exactly once")
+		assert.Equal(t, 1, seenMessages["log-B-2"], "log-B-2 should appear exactly once")
+
+		timestampByMessage := make(map[string]time.Time)
+		for _, log := range logs {
+			timestampByMessage[log.Message()] = log.Timestamp()
+		}
+
+		assert.Equal(t, t50, timestampByMessage["log-A-1"])
+		assert.Equal(t, t30, timestampByMessage["log-A-2"])
+		assert.Equal(t, t45, timestampByMessage["log-B-1"])
+		assert.Equal(t, t40, timestampByMessage["log-B-2"])
+	})
 }
 
 // TestClient_QueryRange_SameTimestamp_Integration documents a known pagination limitation: if more


### PR DESCRIPTION
Frigg uses Loki's [`query_range`](https://grafana.com/docs/loki/v2.9.x/reference/api/#query-loki-over-a-range-of-time) endpoint to fetch logs. The endpoint defaults to returning only the first 100 logs. This can be configured with the `limit` query paremeter.

Previously, Frigg's Loki client would only query logs once and return whatever it got back, even if there were more logs in the requested span of time. This is a severe issue as it means dashboard read logs may be missed, causing Frigg to erroneously conclude that a dashboard is not used.

With the changes in this pull request, Frigg's Loki client continues paging through logs until no more logs remain in the requested span of time. Regrettably, Loki does not return any information on whether more logs remain, so Frigg has to check if the count of logs returned is the same as the limit set. If it is, then Frigg continues paging. When continuing to the next page, Frigg uses a new start time of `maximum_log_timestamp + 1 nanosecond`. 

This leads to an interesting edge case: Frigg will miss some logs if tons of logs have the exact same timestamp. The maximum value of `limit` when fetching logs from Loki is controlled by Loki's [`max_entries_limit_per_query`](https://grafana.com/docs/loki/v2.9.x/configure/#limits_config) configuration option. If Loki's maximum limit is _N_ and there are _N+1_ logs at the exact same nanosecond timestamp, then I don't see a way for Frigg to fetch them all. Given that Frigg queries dashboard read logs, I consider it unlikely that there will be thousands of these logs with the exact same timestamp.

The limit is hardcoded at 100 logs. In a future pull request, I will add a YAML configuration option to control the limit.